### PR TITLE
Catch error when user doesn't have a stylus initialized

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,8 +401,11 @@ function drawStep(id, point) {
 }
 
 function getEventPoint(e) {
-  if (!useMouse || !plugin.penAPI || !plugin.penAPI.pressure){
-    alert("Whoops. Unable to determine Pen Pressure. Please ensure your stylus is properly set up.");
+  
+  // If pen pressure can't be retrieved,
+  // assume that we're using a mouse
+  if (!plugin.penAPI || !plugin.penAPI.pressure) {
+    useMouse = true;
   }
 
   var point = {


### PR DESCRIPTION
I noticed that the program assumes a user has a stylus / wacom pen set up. I'm not sure if this is the correct approach, but I figured it would be worth a try to catch the error before it happens.
